### PR TITLE
ensure modelOrCollection is object - fix #7

### DIFF
--- a/ampersand-react-mixin.js
+++ b/ampersand-react-mixin.js
@@ -22,7 +22,7 @@ module.exports = events.createEmitter({
     watch: function (modelOrCollection, opts) {
         var events;
 
-        if (typeof modelOrCollection === 'object'){
+        if (modelOrCollection !== null && typeof modelOrCollection === 'object'){
           if (modelOrCollection.isCollection) {
               events = 'add remove reset';
           } else if (modelOrCollection.isState) {

--- a/ampersand-react-mixin.js
+++ b/ampersand-react-mixin.js
@@ -18,14 +18,20 @@ var deferbounce = function (fn) {
 };
 
 module.exports = events.createEmitter({
+
     watch: function (modelOrCollection, opts) {
         var events;
-        if (modelOrCollection.isCollection) {
-            events = 'add remove reset';
-        } else if (modelOrCollection.isState) {
-            events = 'change';
-        } else {
-            return;
+
+        if (typeof modelOrCollection === 'object'){
+          if (modelOrCollection.isCollection) {
+              events = 'add remove reset';
+          } else if (modelOrCollection.isState) {
+              events = 'change';
+          }
+        }
+
+        if (!events){
+          return;
         }
 
         this.listenTo(modelOrCollection, events, deferbounce(bind(this.forceUpdate, this)));


### PR DESCRIPTION
An updated fix with null check. Good catch @lukekarrys. @pgilad did not go with lodash isObject since it is not exported from the required lodash dependencies. Seemed like overkill to add a dependency when @lukekarrys fix was sufficient. Cheers!
