### PR TITLE
just call forceUpdate if component is mounted

### DIFF
--- a/ampersand-react-mixin.js
+++ b/ampersand-react-mixin.js
@@ -16,6 +16,12 @@ var deferbounce = function (fn) {
     }
 };
 
+var safeForceUpdate = function () {
+    if (this.isMounted()) {
+        this.forceUpdate();
+    }
+};
+
 module.exports = events.createEmitter({
 
     watch: function (modelOrCollection, opts) {
@@ -33,9 +39,9 @@ module.exports = events.createEmitter({
           return;
         }
 
-        this.listenTo(modelOrCollection, events, deferbounce(bind(this.forceUpdate, this)));
+        this.listenTo(modelOrCollection, events, deferbounce(bind(safeForceUpdate, this)));
 
-        if (opts.reRender) this.forceUpdate();
+        if (opts.reRender) safeForceUpdate.call(this);
     },
 
     componentDidMount: function () {


### PR DESCRIPTION
Hi there,

I recently had some warnings when running my tests:

```
Warning: forceUpdate(...): Can only update a mounted or mounting component. This usually means you called forceUpdate() on an unmounted component. This is a no-op.
```

I use `React.unmountComponentAtNode` somewhere in my code that is called in an `afterEach` hook in my tests. So I realized that `ampersand-react-mixin` is calling `forceUpdate` even if the component is not mounted anymore.

This PR tries to solve the problem.
