### PR TITLE
remove isMounted() as it's deprecated in React 16

### DIFF
--- a/ampersand-react-mixin.js
+++ b/ampersand-react-mixin.js
@@ -17,7 +17,7 @@ var deferbounce = function (fn) {
 };
 
 var safeForceUpdate = function () {
-    if (this.isMounted()) {
+    if (this.__isMounted) {
         this.forceUpdate();
     }
 };
@@ -52,9 +52,11 @@ module.exports = events.createEmitter({
         if (this.autoWatch !== false) {
             forEach(this.props, this.watch, this);
         }
+        this.__isMounted = true;
     },
 
     componentWillUnmount: function () {
         this.stopListening();
+        this.__isMounted = false;
     }
 });


### PR DESCRIPTION
use this.__isMounted instead of .isMounted() (as it's deprecated in React 16.xx) to check if a Component was mounted or not