### PR TITLE
Remove deprecated isMounted()

### DIFF
--- a/ampersand-react-mixin.js
+++ b/ampersand-react-mixin.js
@@ -17,7 +17,7 @@ var deferbounce = function (fn) {
 };
 
 var safeForceUpdate = function () {
-    if (this.isMounted()) {
+    if (this._isMounted) {
         this.forceUpdate();
     }
 };
@@ -45,6 +45,7 @@ module.exports = events.createEmitter({
     },
 
     componentDidMount: function () {
+        this._isMounted = true;
         var watched = this.getObservedItems && this.getObservedItems();
         if (watched) {
             forEach(watched, this.watch, this);
@@ -55,6 +56,7 @@ module.exports = events.createEmitter({
     },
 
     componentWillUnmount: function () {
+        this._isMounted = false;
         this.stopListening();
     }
 });


### PR DESCRIPTION
React has deprecated isMounted() and recommends migrating this way: 
An easy migration strategy for anyone upgrading their code to avoid isMounted() is to track the mounted status yourself. Just set a _isMounted property to true in componentDidMount and set it to false in componentWillUnmount, and use this variable to check your component’s status.
https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
This also fixes the console warning thrown by React about the deprecated isMounted()